### PR TITLE
Make sure any other hooks are fired after we're in

### DIFF
--- a/pvtl-sso.php
+++ b/pvtl-sso.php
@@ -200,10 +200,13 @@ class PvtlSso {
 		}
 
 		// We'll rotate the password, to prevent users manually changing it to get past SSO.
-		$this->rotate_password( $user->ID );
+		$password = $this->rotate_password( $user->ID );
 
 		// Login.
 		wp_set_auth_cookie( $user->ID, true );
+
+		// Make sure any other (eg. plugin's) hooks are fired after we're logged in (eg. logging).
+		apply_filters( 'authenticate', $user, $user->user_login, $password );
 
 		// Update the user on each login, to keep the user's data up to date.
 		if ( ! $this->update_user( $user->ID ) ) {


### PR DESCRIPTION
Other plugins make use of/rely on the 'authenticate' hook - which we weren't firing.
This PR makes sure any other (eg. plugin's) hooks are fired after we're logged in - particularly useful for authentication logging plugin.